### PR TITLE
Fix `intersect:` for elements in view on page load 

### DIFF
--- a/src/observer.js
+++ b/src/observer.js
@@ -13,6 +13,8 @@ const Observer = {
         const elements = document.querySelectorAll('[class*=" intersect:"],[class*=":intersect:"],[class^="intersect:"]');
 
         elements.forEach(element => {
+            element.setAttribute("no-intersect", "");
+
             let observer = new IntersectionObserver(entries => {
                 entries.forEach(entry => {
                     if (! entry.isIntersecting) {


### PR DESCRIPTION
If you used this utility to transition elements that are in view for the initial load, the transitions are not triggered.

Setting the `no-intersect` attribute on all elements fixes this issue.