### PR TITLE
Added a restart function to the Observer object, useful when using react-router in a react app

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -4,6 +4,7 @@ declare const intersect: {
 
 declare const Observer: {
     start(): void,
+    restart(): void,
     observe(): void,
     getThreshold(element: HTMLElement): number,
 }

--- a/src/observer/index.js
+++ b/src/observer/index.js
@@ -9,7 +9,12 @@ const Observer = {
         this.observe()
     },
 
-    observe() {
+    restart() {
+        this.observe(true)
+        this.observe()
+    },
+
+    observe(unobserve = false) {
         const selectors = [
             '[class*=" intersect:"]',
             '[class*=":intersect:"]',
@@ -23,6 +28,12 @@ const Observer = {
         document.querySelectorAll(selectors.join(',')).forEach(element => {
             const observer = new IntersectionObserver(entries => {
                 entries.forEach(entry => {
+
+                    if(unobserve) {
+                        observer.disconnect()
+                        return
+                    }
+
                     if (! entry.isIntersecting) {
                         element.setAttribute('no-intersect', '')
 


### PR DESCRIPTION
Hi, I was having an issue when using `intersect-once`, I've been using this plugin in combination with [tailwindcss-motion](https://github.com/romboHQ/tailwindcss-motion) in order to play animation **only once on scroll** in my react app.

# the issue

When switching between routes on the frontend using `react-router` below elements animations will be played too early as if the user scrolled on them which resulted in animation not playing properly for the user since it was "already intersected" which shouldn't happen, in reality the user didn't scroll on those elements, it's supposed to reset since it's a new route.

# the fix

I thought why not implementing a tiny restart function that will be triggered on each route change, it removes existing observers before attaching a new one, simple yet was an effective solution to my issue when routing in my react app, and I felt sharing this might be useful for other people that are facing the same issue.

```tsx
import { Observer } from "tailwindcss-intersect";
import { useEffect } from "react";
import { useLocation } from "react-router";

export default function ObserverProvider({ children }: { children: React.ReactNode }) {
    const { pathname } = useLocation();

    useEffect(() => {
        Observer.restart();
    }, [pathname]);

    return <>{children}</>;
}
```



